### PR TITLE
Add only option to deploy

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -48,6 +48,9 @@ export default class Deploy extends Command {
     if (!!this.parsedFlags && this.parsedFlags.force) {
       process.env.STACKPATH_FORCE = this.parsedFlags.force;
     }
+    if (!!this.parsedFlags && this.parsedFlags.force) {
+      process.env.STACKPATH_ONLY = this.parsedFlags.only;
+    }
 
     Log.logVerbose(`Checking if access token expired?`);
 
@@ -66,7 +69,11 @@ export default class Deploy extends Command {
     const deploy = new DeployService();
     try {
       await deploy.deployScripts({
-        force: Boolean(process.env.STACKPATH_FORCE)
+        force: Boolean(process.env.STACKPATH_FORCE),
+        only:
+          typeof process.env.STACKPATH_ONLY === "string"
+            ? process.env.STACKPATH_ONLY.split(",")
+            : undefined
       });
     } catch (e) {
       cliUx.log(e.message);


### PR DESCRIPTION
Adds option for an only argument to deploy.

`sp-serverless deploy --only my-script-name`

Or multiple scripts, comma-separated:

`sp-serverless deploy --only my-script-name,my-other-script`

This is necessary when you want to be able to deploy a staging script or production script. It does almost require you to name your scripts concisely and without spaces.