### PR TITLE
Add --only documentation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ node_js:
   - "10"
   - "11"
   - "12"
+  - "13"
 
 matrix:
   allow_failures:

--- a/README.md
+++ b/README.md
@@ -223,9 +223,10 @@ USAGE
   $ sp-serverless deploy
 
 OPTIONS
-  -f, --force    Force recreation of scripts if they do not exist. Defaults to false
-  -h, --help     show CLI help
-  -v, --verbose  Turns on verbose logging. Defaults to false
+  -f, --force      Force recreation of scripts if they do not exist. Defaults to false
+  -h, --help       show CLI help
+  -o, --only=only  Only deploy the following script named scripts. Comma separated value of script names. Defaults to ""
+  -v, --verbose    Turns on verbose logging. Defaults to false
 
 EXAMPLE
   $ sp-serverless deploy

--- a/README.md
+++ b/README.md
@@ -1,46 +1,37 @@
 # Serverless Scripting CLI
 
-StackPath's serverless scripting platform allows you to add custom logic to your
-applications or even build entire applications on the edge. With a simple deploy
-your scripts are deployed to StackPath's vast network containing over 45 POP's.
+StackPath's [serverless scripting platform](https://www.stackpath.com/products/serverless-scripting/)
+allows you to add custom logic to your applications or even build entire
+applications on the edge. A single deployment distributes your scripts across
+StackPath's vast network containing over 45 POPs.
+
 This CLI makes deploying as easy as running a single command, no matter the
-amount of scripts you have.
+number of scripts you have. It's easy to use, but allows for a variety of use
+cases. Run the CLI locally to make for fast deployments, run it in a CI/CD
+pipeline to automate deployments, or implement it in any other way you can think
+of.
 
 [![Version](https://img.shields.io/npm/v/@stackpath/serverless-scripting-cli.svg)](https://www.npmjs.com/package/@stackpath/serverless-scripting-cli)
 [![Downloads/week](https://img.shields.io/npm/dw/@stackpath/serverless-scripting-cli.svg)](https://www.npmjs.com/package/@stackpath/serverless-scripting-cli)
 [![License](https://img.shields.io/npm/l/@stackpath/serverless-scripting-cli.svg?style=flat)](https://github.com/stackpath/serverless-scripting-cli/blob/master/LICENSE.md)
 [![Build Status](https://travis-ci.org/stackpath/serverless-scripting-cli.svg)](https://travis-ci.org/stackpath/serverless-scripting-cli)
 
-# Introduction
+## Installation
 
-This CLI makes deploying to the serverless scripting platform as easy as running
-a single command. It's easy to use, but allows for a variety of use-cases. You
-can run the CLI locally to make deploying a whole lot quicker, run it in a CI/CD
-pipeline to automate the deployments, or implement it in any way you can think of.
+Run any of the following commands to install the CLI depending on your platform
+and preferences:
 
-**How to get started?**
-
-1. [Install the CLI](#installing-the-cli)
-2. [Save your credentials](#setting-authentication-details)
-3. [Set up the configuration file](#configure-project)
-4. [Deploy](#deploying-with-the-cli)
-
-## Installing the CLI
-
-Depending on your platform and preferences there are a couple of ways to get the
-CLI.
-
-### Installing through NPM
+### Using NPM
 
 Run `npm install -g @stackpath/serverless-scripting-cli` to install `sp-serverless`
 as a global package.
 
-### Installing through Yarn
+### Using Yarn
 
 Run `yarn global add @stackpath/serverless-scripting-cli` to install `sp-serverless`
 as a global package.
 
-### Installing through Homebrew or Linuxbrew
+### Using Homebrew or Linuxbrew
 
 StackPath maintains a [Homebrew tap](https://github.com/stackpath/homebrew-stackpath)
 for users to access utilities through the popular [Homebrew](https://brew.sh/)
@@ -50,21 +41,26 @@ Linux.
 Run `brew tap stackpath/stackpath` to install the tap, then run `brew install sp-serverless`
 to install the `sp-serverless` utility.
 
-## Setting authentication details
+## Configuration
+
+Perform the following to configure the CLI utility after it's installed:
+
+### Setting authentication details
 
 The CLI saves your authentication data in a file in your home directory
-(`~/.stackpath/credentials`). Once you have set this up, the CLI will continue
-to read the credentials from the file, meaning that you don't have to provide
+(`~/.stackpath/credentials`). Once this is set up, the CLI will continue
+to read the credentials from the file, meaning you don't have to provide
 your credentials over and over again.
 
-In order to authenticate yourself, you need a client ID and a client secret. You
-can find them in [the StackPath client portal](https://control.stackpath.com/api-management).
+You need a StackPath API client ID and client secret in order to authenticate.
+You can find them in [the StackPath customer portal](https://control.stackpath.com/api-management).
 
-### Authenticating in an interactive environment (e.g. on your local machine)
+#### Authenticating in an interactive environment (e.g. on your local machine)
 
-> 👉 To authenticate in an interactive environment you can simply run `sp-serverless auth`. The CLI will prompt you for required details.
+Run `sp-serverless auth` to authenticate in an interactive environment. The CLI
+will prompt you for required details.
 
-### Authenticating in a **non**-interactive environment (e.g. in a CI/CD pipeline)
+#### Authenticating in a non-interactive environment (e.g. in a CI/CD pipeline)
 
 Are you integrating the CLI with a non-interactive environment? Then provide the
 client ID and the client secret as flags of the command. For example:
@@ -76,23 +72,21 @@ sp-serverless auth --client_id example-client-id --client_secret example-client-
 Use the `--force` (or `-f`) flag so that the credentials file is always
 overwritten, even if it already exists.
 
-## Configure project
+### Configuring a project
 
 The serverless scripting CLI works with a per-project (or per-directory) based
 configuration. Each project should have its own configuration file defining the
-scripts that apply to that project. You might use it to order scripts by
-website, category (such as firewalls), or otherwise.
+scripts that apply to that project. You might use it to order scripts by site,
+category (such as firewalls), or otherwise.
 
-Start by including a `sp-serverless.json`-file in your project directory. The
-required contents can be found below 👇.
+Start by creating a `sp-serverless.json` file in your project's directory.
 
-### stackpath-serverless.json configuration file
+#### The configuration file
 
-When deploying (`sp-serverless deploy`), the CLI tries to find the `sp-serverless.json`
+When deploying via `sp-serverless deploy`, the CLI looks for the `sp-serverless.json`
 configuration file in the directory you're running the command from. Through
 this file you can configure which scripts you'd like to deploy to which site.
-
-Here's an example:
+For example:
 
 ```
 {
@@ -105,7 +99,7 @@ Here's an example:
         "admin/*"
       ],
       "file": "serverless_scripts/ip-firewall.js",
-      // The ID is generated on first deploy, or - optionally - you can configure it yourself.
+      // The ID is generated on first deploy, or optionally you can configure it yourself.
       "id": "dcdf7824-b6bd-42b8-9b16-9235eefd583d"
     },
     {
@@ -129,74 +123,43 @@ Here's an example:
 }
 ```
 
-> Note that you can define the `site_id` either in a global scope or in a per-script scope. This allows you to deploy to different sites from a single configuration file.
+Note that you can define the `site_id` either in a global scope or in a
+per-script scope. This allows you to deploy to different sites from a single
+configuration file.
 
-### Overview of all configuration parameters
+The configuration file contains the following parameters:
 
-| Key                | Description                                                                                                                                                                            |
-| ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `stack_id`         | The ID of the stack where your site is in.                                                                                                                                             |
-| `site_id`          | The ID of the site you'd like to apply the scripts to.                                                                                                                                 |
-| `scripts[name]`    | The name of the script. This should be descriptive and unique to each site.                                                                                                            |
-| `scripts[paths][]` | The paths the script should apply to. Relative to your site. **Without starting `/`**. If you'd like to apply the script to `http://example.org/admin/*` you'd use the `admin/*` path. |
-| `scripts[file]`    | The file where the required JS is in. Define the path relative to the serverless configuration JSON. Without a starting `/`.                                                           |
-| `scripts[id]`      | The ID of the script in the serverless scripting platform. Will be created after first deploy. Should be checked into version control after being created.                             |
+- **`stack_id`**: The ID or slug of the stack where your site is in
+- **`site_id`**: The ID of the site to apply the scripts to
+- **`scripts[name]`**: The name of the script. This should be descriptive and unique to each site
+- **`scripts[paths][]`**: The HTTP request paths the script should apply to, relative to the site root and without an initial `/`. For example, use the path `admin/*` to apply the script to requests to `https://example.org/admin/*`
+- **`scripts[file]`**: The local path to the JavaScript file to use as the serverless script, relative to `sp-serverless.json`'s path and without an initial `/`.
+- **`scripts[id]`**: The ID of the script in the serverless scripting platform. This is created after your first deployment. It should be checked into version control after being created
 
-### Where to find the stack and site ID?
+#### Finding the stack slug and site ID
 
-You can find the stack and site ID in the URL when you're logged into the
-StackPath client portal and have selected the CDN site you'd like to deploy
-scripts to. See the illustration below for more information on which IDs to copy.
+Find the stack slug and site ID in the URL when you're logged into the StackPath
+customer portal and have selected the CDN site you'd like to deploy scripts to.
 
-![How to find the IDs in the URL](https://cdn.developer.stackpath.com/assets/github.com/stackpath/edgeengine-cli/README.md/finding-stack-and-site-id.png)
+## Deploying serverless scripts
 
-## Deploying with the CLI
-
-When talking about deploying in the context of the serverless scripting platform
-we mean getting local code onto the StackPath Edge. You might also call it
-"updating" or "pushing" code.
-
-> 👉 Deploying is as easy as running `sp-serverless deploy` from your project directory (given it has the `sp-serverless.json`-file).
+Run `sp-serverless deploy` from your project directory. To push your configured
+scripts to the StackPath edge.
 
 ### Deploying from a non-interactive environment
 
-During the deployment the CLI might prompt you in certain situations. For
-example, when your `sp-serverless.json` holds an ID that can not be found in the
-platform. The CLI will then prompt you if you'd like to re-create the script. In
-non-interactive environments you can use the `--force` or `-f` flag to always
-try to re-create the script.
+The CLI may prompt you in certain situations when deploying scripts. For
+example, if your `sp-serverless.json` file contains an ID that cannot be found
+in the platform, the CLI will then prompt you if you'd like to re-create the
+script. Use the `--force` or `-f` flag to always try to re-create the script.
 
-# Usage
+## Usage
 
-<!-- usage -->
+### `sp-serverless auth`
 
-```sh-session
-$ npm install -g @stackpath/serverless-scripting-cli
-$ sp-serverless COMMAND
-running command...
-$ sp-serverless (-v|--version|version)
-@stackpath/serverless-scripting-cli/2.0.0 darwin-x64 node-v10.15.0
-$ sp-serverless --help [COMMAND]
-USAGE
-  $ sp-serverless COMMAND
-...
 ```
-
-<!-- usagestop -->
-
-# Commands
-
-<!-- commands -->
-
-- [`sp-serverless auth`](#sp-serverless-auth)
-- [`sp-serverless deploy`](#sp-serverless-deploy)
-- [`sp-serverless help [COMMAND]`](#sp-serverless-help-command)
-
-## `sp-serverless auth`
-
 Configures StackPath's authentication details.
 
-```
 USAGE
   $ sp-serverless auth
 
@@ -211,50 +174,45 @@ EXAMPLE
   $ sp-serverless auth
 ```
 
-_See code: [src/commands/auth.ts](https://github.com/stackpath/serverless-scripting-cli/blob/master/src/commands/auth.ts)_
-
-## `sp-serverless deploy`
-
-Deploys the scripts in the working directory according to its `sp-serverless.json`
-configuration file.
+### `sp-serverless deploy`
 
 ```
+Deploys the scripts in the working directory according to its sp-serverless.json configuration file.
+
 USAGE
   $ sp-serverless deploy
 
 OPTIONS
-  -f, --force      Force recreation of scripts if they do not exist. Defaults to false
-  -h, --help       show CLI help
-  -o, --only=only  Only deploy the following script named scripts. Comma separated value of script names. Defaults to ""
-  -v, --verbose    Turns on verbose logging. Defaults to false
+  -f, --force    Force recreation of scripts if they do not exist. Defaults to false
+  -h, --help     show CLI help
+  -v, --verbose  Turns on verbose logging. Defaults to false
 
 EXAMPLE
   $ sp-serverless deploy
 ```
 
-_See code: [src/commands/deploy.ts](https://github.com/stackpath/serverless-scripting-cli/blob/master/src/commands/deploy.ts)_
-
-## `sp-serverless help [COMMAND]`
-
-Display usage information.
+### `sp-serverless help`
 
 ```
+Deploy to StackPath's serverless scripting platform from your local machine.
+
+VERSION
+  @stackpath/serverless-scripting-cli/2.0.1 darwin-x64 node-v13.12.0
+
 USAGE
-  $ sp-serverless help [COMMAND]
+  $ sp-serverless [COMMAND]
 
-ARGUMENTS
-  COMMAND  command to show help for
-
-OPTIONS
-  --all  see all commands in CLI
+COMMANDS
+  auth    Configures StackPath's authentication details.
+  deploy  Deploys the scripts in the working directory according to its sp-serverless.json configuration file.
+  help    display help for sp-serverless
 ```
 
-_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v2.1.4/src/commands/help.ts)_
+# Development
 
-<!-- commandsstop -->
+The CLI doesn't have any build commands. Make code changes and run `yaen test` to
+run the test suite or `bin/run` to test changes directly.
 
-# Contributing
-
-We welcome contributions and pull requests to this plugin. See our
+We welcome contributions and pull requests. See our
 [contributing guide](https://github.com/stackpath/serverless-scripting-cli/blob/master/.github/contributing.md)
 for more information.

--- a/src/api/services/deploy.ts
+++ b/src/api/services/deploy.ts
@@ -184,7 +184,7 @@ export class Deploy {
   /**
    * Update the id of the script into the configuration object.
    * @param {IConfigurationScript} script - The script that needs to be updated.
-   * @param {Response} response - The response that contains the (new) id.
+   * @param {string} scriptId - The new script ID.
    * @param {number} index - The index of the script.
    */
   private async updateScriptIdInConfig(

--- a/src/api/services/http.ts
+++ b/src/api/services/http.ts
@@ -9,7 +9,6 @@ import * as Log from "./log";
  * @param {string} method The http method used to perform the call
  * @param {string} resource - The endpoint relative to the hostname, be sure to prefix with a forward slash '/'.
  * @param [body] - The optional payload that will be sent to the server.
- * @param {boolean} throwErrors - If false, handle the error yourself, timeout errors will still be thrown. Defaults to true.
  * @returns {Promise<Response>} - The response of the server.
  */
 export async function request(

--- a/src/api/services/prompt.ts
+++ b/src/api/services/prompt.ts
@@ -2,7 +2,7 @@ import cliUx from "cli-ux";
 
 /**
  * Prompts the user if they want to continue or not after an error.
- * @param {string} log - The string that needs to be logged to the output.
+ * @param {any} e - The item to log to the output.
  */
 export async function continueOnErrorPrompt(e: any) {
   if (!process.env.STACKPATH_FORCE) {

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -29,7 +29,7 @@ export default class Auth extends Command {
     force: flags.boolean({
       char: "f",
       description:
-        "Set this to always overwrite current credential file, defaults to false.",
+        "Set this to always overwrite current credential file. Defaults to false",
       default: false
     }),
     help: flags.help({ char: "h" }),

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -29,6 +29,12 @@ export default class Deploy extends Command {
       description:
         "Force recreation of scripts if they do not exist. Defaults to false",
       default: false
+    }),
+    only: flags.string({
+      char: "o",
+      description:
+        'Only deploy the following script named scripts. Comma separated value of script names. Defaults to ""',
+      default: ""
     })
   };
 
@@ -48,7 +54,7 @@ export default class Deploy extends Command {
     if (!!this.parsedFlags && this.parsedFlags.force) {
       process.env.STACKPATH_FORCE = this.parsedFlags.force;
     }
-    if (!!this.parsedFlags && this.parsedFlags.force) {
+    if (!!this.parsedFlags && this.parsedFlags.only) {
       process.env.STACKPATH_ONLY = this.parsedFlags.only;
     }
 


### PR DESCRIPTION
Changes proposed in this pull request:
* Run the test suite in node 13
* Add documentation and command options for the `--only` flag
* Tweak README readability
* Fix inaccurate internal docblocks
